### PR TITLE
Add domain validation functionality and update to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@ Status](https://github.com/IntelligentRoboticsLabs/plansys2_tfd_plan_solver/work
 
 This package contains a plan solver that uses [Temporal Fast Downward](http://gki.informatik.uni-freiburg.de/tools/tfd/) for solving PDDL plans.
 
-To install `Temporal Fast TFD` in a the $TFD_HOME directory:
+To install Temporal Fast Downward (TFD) to work with PlanSys2:
 
-1. `mkdir -p $TFD_HOME`
-2. `cd $TFD_HOME`
-3. `wget "http://gki.informatik.uni-freiburg.de/tools/tfd/downloads/version-0.4/tfd-src-0.4.tgz"`
-4. `tar xzf "tfd-src-0.4.tgz"`
-5. `cd "tfd-src-0.4"`
-6. `sed -e s/"-Werror"//g -i ./downward/search/Makefile`
-7. `./build`
-8. Add an `export TFD_HOME=` to ~.bashrc that points to the `downward` directory.
+1. Pick an installation folder, e.g., `${HOME}/plansys2`
+2. `mkdir -p ${HOME}/plansys2`
+3. `cd ${HOME}/plansys2`
+4. `git clone https://github.com/sea-bass/TemporalFastDownward.git`
+5. `cd TemporalFastDownward`
+6. `./build`
+7. Export a `$TFD_HOME` environment variable that points to the `downward` directory, e.g., `export TFD_HOME=${HOME}/plansys2/TemporalFastDownward/downward`.
+8. (Optional) Add the above export statement to your `~/.bashrc` file.
 
 ### Manual execution of TFD
 
-1. `python2.7 $TFD_HOME/translate/translate.py [domain_name].pddl [problem_name].pddl`
+1. `python3 $TFD_HOME/translate/translate.py [domain_name].pddl [problem_name].pddl`
 2. `$TFD_HOME/preprocess/preprocess < output.sas`
 3. `$TFD_HOME/search/search y Y a T 10 t 5 e r O 1 C 1 p $TFD_HOME/plan < output`
+4. `cat pddlplan.1`

--- a/include/plansys2_tfd_plan_solver/tfd_plan_solver.hpp
+++ b/include/plansys2_tfd_plan_solver/tfd_plan_solver.hpp
@@ -29,14 +29,20 @@ class TFDPlanSolver : public PlanSolverBase
 public:
   TFDPlanSolver();
 
-  void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr & node, const std::string & id);
+  void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr, const std::string &);
 
   std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,
     const std::string & node_namespace = "");
 
+  bool isDomainValid(
+    const std::string & domain,
+    const std::string & node_namespace = "");
+
 private:
   std::string tfd_path_;
+  std::string output_dir_parameter_name_;
+  rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node_;
 };
 
 }  // namespace plansys2

--- a/src/plansys2_tfd_plan_solver/tfd_plan_solver.cpp
+++ b/src/plansys2_tfd_plan_solver/tfd_plan_solver.cpp
@@ -15,17 +15,16 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <string>
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
+#include <regex>
+#include <string>
 
 #include "plansys2_msgs/msg/plan_item.hpp"
 #include "plansys2_tfd_plan_solver/tfd_plan_solver.hpp"
-#include "pluginlib/class_list_macros.hpp"
-
-PLUGINLIB_EXPORT_CLASS(plansys2::TFDPlanSolver, plansys2::PlanSolverBase);
 
 namespace plansys2
 {
@@ -35,18 +34,24 @@ TFDPlanSolver::TFDPlanSolver()
 }
 
 void
-TFDPlanSolver::configure(rclcpp_lifecycle::LifecycleNode::SharedPtr & node, const std::string & id)
+TFDPlanSolver::configure(
+  rclcpp_lifecycle::LifecycleNode::SharedPtr lc_node,
+  const std::string & plugin_name)
 {
-  char * planner_path = getenv("TFD_HOME");
+  lc_node_ = lc_node;
 
+  output_dir_parameter_name_ = plugin_name + ".output_dir";
+  lc_node_->declare_parameter<std::string>(
+    output_dir_parameter_name_, std::filesystem::temp_directory_path());
+
+  char * planner_path = getenv("TFD_HOME");
   if (planner_path == NULL) {
-    RCLCPP_FATAL(node->get_logger(), "'TFD_HOME' end not defined for %s", id.c_str());
+    RCLCPP_FATAL(
+      lc_node_->get_logger(), "'TFD_HOME' environment variable not defined for %s",
+      plugin_name.c_str());
     exit(-1);
   }
-
   tfd_path_ = std::string(planner_path);
-
-  RCLCPP_INFO(node->get_logger(), "Planner path set to: %s", tfd_path_.c_str());
 }
 
 std::optional<plansys2_msgs::msg::Plan>
@@ -54,47 +59,74 @@ TFDPlanSolver::getPlan(
   const std::string & domain, const std::string & problem,
   const std::string & node_namespace)
 {
-  if (node_namespace != "") {
-    //  This doesn't work as cxx flags must apper at end of link options, and I didn't
-    //  find a way
-    // std::experimental::filesystem::create_directories("/tmp/" + node_namespace);
-    mkdir(("/tmp/" + node_namespace).c_str(), ACCESSPERMS);
+  if (system(nullptr) == 0) {
+    return {};
   }
 
+  auto output_dir = std::filesystem::path(
+    lc_node_->get_parameter(output_dir_parameter_name_).value_to_string()
+  );
+
+  if (node_namespace != "") {
+    for (auto p : std::filesystem::path(node_namespace) ) {
+      if (p != std::filesystem::current_path().root_directory()) {
+        output_dir /= p;
+      }
+    }
+    std::filesystem::create_directories(output_dir);
+  }
+  RCLCPP_INFO(
+    lc_node_->get_logger(), "Writing planning results to %s.", output_dir.string().c_str());
+
+  int status;
   plansys2_msgs::msg::Plan ret;
-  std::ofstream domain_out("/tmp/" + node_namespace + "/domain.pddl");
+
+  const auto domain_file_path = output_dir / std::filesystem::path("domain.pddl");
+  std::ofstream domain_out(domain_file_path);
   domain_out << domain;
   domain_out.close();
 
-  std::ofstream problem_out("/tmp/" + node_namespace + "/problem.pddl");
+  const auto problem_file_path = output_dir / std::filesystem::path("problem.pddl");
+  std::ofstream problem_out(problem_file_path);
   problem_out << problem;
   problem_out.close();
 
-  system(
+  // Translate the domain and problem files to SAS.
+  const auto output_sas_file_path = output_dir / std::filesystem::path("output.sas");
+  status = system(
     (tfd_path_ + "/translate/translate.py " +
-    "/tmp/" + node_namespace + "/domain.pddl " +
-    "/tmp/" + node_namespace + "/problem.pddl").c_str()
+    domain_file_path.string() + " " + problem_file_path.string()).c_str()
   );
+  if (status == -1) {
+    RCLCPP_ERROR_STREAM(lc_node_->get_logger(), "Failed to translate domain and problem files.");
+    return {};
+  }
+  system(("mv output.sas " + output_sas_file_path.string()).c_str());
 
-  system(
-    ("mv output.sas /tmp/" + node_namespace).c_str()
+  // Preprocess the translated files.
+  const auto processed_output_file_path = output_dir / std::filesystem::path("output");
+  status = system(
+    (tfd_path_ + "/preprocess/preprocess < " + output_sas_file_path.string()).c_str()
   );
+  if (status == -1) {
+    RCLCPP_ERROR_STREAM(lc_node_->get_logger(), "Failed to preprocess files.");
+    return {};
+  }
+  system(("mv output " + processed_output_file_path.string()).c_str());
 
-  system(
-    (tfd_path_ + "/preprocess/preprocess < /tmp/output.sas").c_str()
+  // Search for a plan using TFD
+  const auto pddlplan_file_path = output_dir / std::filesystem::path("pddlplan");
+  status = system(
+    (tfd_path_ + "/search/search y Y a T 10 t 5 e r O 1 C 1 p " +
+    pddlplan_file_path.string() + " < " + processed_output_file_path.string()).c_str()
   );
-
-  system(
-    ("mv output /tmp/" + node_namespace).c_str()
-  );
-
-  system(
-    (tfd_path_ + "/search/search y Y a T 10 t 5 e r O 1 C 1 p /tmp/" +
-    node_namespace + "/pddlplan < /tmp/" + node_namespace + "/output").c_str()
-  );
+  if (status == -1) {
+    RCLCPP_ERROR_STREAM(lc_node_->get_logger(), "Failed to search for a plan.");
+    return {};
+  }
 
   std::string line;
-  std::ifstream plan_file("/tmp/" + node_namespace + "/pddlplan.1");
+  std::ifstream plan_file(pddlplan_file_path.string() + ".1");
   bool solution = false;
 
   if (plan_file.is_open()) {
@@ -118,9 +150,16 @@ TFDPlanSolver::getPlan(
     plan_file.close();
   }
 
-  system("mv /tmp/output /tmp/output.last");
-  system("mv /tmp/pddlplan.1 /tmp/pddlplan.1.last");
-  system("mv /tmp/output.sas /tmp/output.sas.last");
+  // Save all the output files with a ".last" mangle.
+  system(
+    ("mv " + output_sas_file_path.string() + " " +
+    output_sas_file_path.string() + ".last").c_str());
+  system(
+    ("mv " + processed_output_file_path.string() + " " +
+    processed_output_file_path.string() + ".last").c_str());
+  system(
+    ("mv " + pddlplan_file_path.string() + ".1 " +
+    pddlplan_file_path.string() + ".1.last").c_str());
 
   if (ret.items.empty()) {
     return {};
@@ -129,4 +168,73 @@ TFDPlanSolver::getPlan(
   }
 }
 
+bool
+TFDPlanSolver::isDomainValid(
+  const std::string & domain,
+  const std::string & node_namespace)
+{
+  if (system(nullptr) == 0) {
+    return false;
+  }
+
+  auto output_dir = std::filesystem::path(
+    lc_node_->get_parameter(output_dir_parameter_name_).value_to_string()
+  );
+
+  if (node_namespace != "") {
+    for (auto p : std::filesystem::path(node_namespace) ) {
+      if (p != std::filesystem::current_path().root_directory()) {
+        output_dir /= p;
+      }
+    }
+    std::filesystem::create_directories(output_dir);
+  }
+  RCLCPP_INFO(
+    lc_node_->get_logger(), "Writing domain validation results to %s.",
+    output_dir.string().c_str());
+
+  int status;
+  plansys2_msgs::msg::Plan ret;
+
+  const auto domain_file_path = output_dir / std::filesystem::path("domain.pddl");
+  std::ofstream domain_out(domain_file_path);
+  domain_out << domain;
+  domain_out.close();
+
+  // TFD requires the problem to match the domain's problem name.
+  // Get the domain name to put together a valid problem.
+  std::regex regexp("\\(\\s*domain\\s*([^\\)\\s]+)\\s*\\)");
+  std::smatch regex_matches;
+  std::regex_search(domain, regex_matches, regexp);
+  if (regex_matches.size() != 2u) {
+    RCLCPP_ERROR(lc_node_->get_logger(), "Could not extract domain name from domain file.");
+    return false;
+  }
+  const std::string domain_name = regex_matches[1];
+
+  const auto problem_file_path = output_dir / std::filesystem::path("problem.pddl");
+  std::ofstream problem_out(problem_file_path);
+  problem_out << "(define (problem void) (:domain "
+              << domain_name << ") (:objects) (:init) (:goal none))";
+  problem_out.close();
+
+  // Translate the domain and problem files to SAS.
+  // If this is successful, the domain is considered validated.
+  const auto output_val_file_path = output_dir / std::filesystem::path("output.sas.validation");
+  status = system(
+    (tfd_path_ + "/translate/translate.py " +
+    domain_file_path.string() + " " + problem_file_path.string()).c_str()
+  );
+  if (status == -1) {
+    RCLCPP_ERROR_STREAM(lc_node_->get_logger(), "Failed to translate domain and problem files.");
+    return false;
+  }
+  system(("mv output.sas " + output_val_file_path.string()).c_str());
+
+  return true;
+}
+
 }  // namespace plansys2
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(plansys2::TFDPlanSolver, plansys2::PlanSolverBase);


### PR DESCRIPTION
This PR takes inspiration from https://github.com/PlanSys2/ros2_planning_system/pull/275 and implements a way to validate domains with durative actions using TFD.

In the process, I was able to modify TFD to work with Python 3 (https://github.com/sea-bass/TemporalFastDownward) and also cleaned up a lot of the code here.

I tested this on my end and could use TFD both for domain validation and to return a plan successfully.